### PR TITLE
add simple loading spinner at top level

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { Spinner } from "@blueprintjs/core";
+
+export default function Loading() {
+    return (
+        <div className="flex justify-center items-center w-full h-screen">
+            <Spinner />
+        </div>
+    );
+}


### PR DESCRIPTION
https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming

Probably not yet necessary for production (yet) because it loads to fast, but here it is:
https://www.loom.com/share/fbedb39114fe4e0aa1f359f9d6855176

In the future, we can then build in more custom loading states by adding a `loading.tsx` to specific directories.

For example, for `/flow`, something like this:
![image](https://github.com/ReasonScore/rs-editor/assets/3792666/550aaac0-dfad-4c12-b26f-832d23d24d35)
